### PR TITLE
Version info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
+ARG VERSION=undefined
+
 FROM golang:1.12 AS builder
+ARG VERSION
 
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
@@ -11,7 +14,7 @@ RUN dep ensure --vendor-only
 
 COPY cmd/	cmd/
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o prom-rule-reloader github.com/pusher/prom-rule-reloader/cmd
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X main.VERSION=${VERSION}" -a -o prom-rule-reloader github.com/pusher/prom-rule-reloader/cmd
 
 FROM alpine:3.9
 RUN apk --no-cache add ca-certificates

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ $(BINARY): fmt vet
 
 .PHONY: docker-build
 docker-build: check
-	docker build . -t ${IMG}:${VERSION}
+	docker build --build-arg VERSION=${VERSION}  . -t ${IMG}:${VERSION}
 	@echo "$(GREEN)Built $(IMG):$(VERSION)$(NC)"
 
 TAGS ?= latest

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,6 +46,7 @@ var (
 	ruleSelector   string
 	reloadURLFlag  string
 	reloadInterval time.Duration
+	showVersion    bool
 )
 
 var tweakOptions internalinterfaces.TweakListOptionsFunc = func(o *metav1.ListOptions) {
@@ -61,6 +62,7 @@ func main() {
 	cmd.PersistentFlags().StringVar(&ruleSelector, "rule-selector", "app=prometheus,component=rules", "label selector for prometheus rules")
 	cmd.PersistentFlags().StringVar(&reloadURLFlag, "reload-url", "http://127.0.0.1:9090/-/reload", "reload URL to trigger Prometheus reload on")
 	cmd.PersistentFlags().DurationVar(&reloadInterval, "reload-interval", 10*time.Second, "interval between reloading rules")
+	cmd.PersistentFlags().BoolVar(&showVersion, "version", false, "show version and exit")
 
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 
@@ -81,6 +83,11 @@ func newCommand() *cobra.Command {
 		Short: "Prom Rule Reloader aggregates configmaps into prometheus rules",
 		Long:  `Prom Rule Reloader aggregates configmaps into prometheus rules`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if showVersion {
+				fmt.Printf("prom-rule-reloader %s\n", VERSION)
+				os.Exit(0)
+			}
+
 			glog.V(2).Infof("Starting prom-rule-reloader")
 
 			if err := os.MkdirAll(ruleDir, 0777); err != nil {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,4 @@
+package main
+
+// VERSION contains injected version information
+var VERSION = "undefined"


### PR DESCRIPTION
This PR adds a `--version` flag and ensures this is injected at build time.

Based off of #5.