### PR TITLE
Add distclean to make all and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 vendor/
+
+# Local env
 .env
+prom-rule-reloader
+

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ IMG ?= quay.io/pusher/prom-rule-reloader
 .NOTPARALLEL:
 
 .PHONY: all
-all: test build
+all: distclean test build
 
 .PHONY: build
 build: clean $(BINARY)


### PR DESCRIPTION
This adds the binary to `.gitignore` and also includes `distclean` as a dependency for `make all` to ensure that vendored dependencies are always updated on a naive `git pull; make`